### PR TITLE
Return image size in bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Returns an `object` with parsed metada:
 
 * **string** `path` - original image path
 * **string** `name` - original image name
-* **string** `size` - image file size (ex. `4.296MB`)
+* **string** `size` - image file size in bytes (ex. `4504682`)
 * **string** `format` - image format (`JPEG`, `PNG`, `TIFF` etc.)
 * **string** `colorspace` - image colorspace (`RGB`, `CMYK` etc.)
 * **integer** `height` - image pixel height

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 /*jshint laxbreak:true */
 
+var sizeParser = require('filesize-parser');
 var exec = require('child_process').exec, child;
 
 module.exports = function(path, opts, cb) {
@@ -62,8 +63,12 @@ module.exports.parse = function(path, stdout, opts) {
   if (ret.width) { ret.width = parseInt(ret.width, 10); }
   if (ret.height) { ret.height = parseInt(ret.height, 10); }
 
-  if (ret.size && ret.size.substr(ret.size.length - 2) === "BB") {
-    ret.size = ret.size.substr(0, ret.size.length - 1);
+  if (ret.size) {
+    if (ret.size.substr(ret.size.length - 2) === 'BB') {
+      ret.size = ret.size.substr(0, ret.size.length - 1);
+    }
+
+    ret.size = parseInt(sizeParser(ret.size));
   }
 
   if (ret.colorspace && ret.colorspace === 'sRGB') {

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   "engines": {
     "node": ">=0.10",
     "iojs": ">=1.0.0"
+  },
+  "dependencies": {
+    "filesize-parser": "^1.3.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -50,7 +50,14 @@ describe('metadata.parse()', function() {
   it('returns correct size for bogus value', function() {
     assert.deepEqual(metadata.parse(path, 'size=4.296MBB'), {
       path: path,
-      size: '4.296MB'
+      size: 4504682
+    });
+  });
+
+  it('returns size in bytes', function() {
+    assert.deepEqual(metadata.parse(path, 'size=20MB'), {
+      path: path,
+      size: 20 * 1024 * 1024
     });
   });
 
@@ -104,7 +111,7 @@ describe('metadata()', function() {
 
       assert.equal(data.path, './assets/image.jpg');
       assert.equal(data.name, '');
-      assert.equal(data.size, '4.296MB');
+      assert.equal(data.size, 4504682);
       assert.equal(data.format, 'JPEG');
       assert.equal(data.colorspace, 'RGB');
       assert.equal(data.height, 3456);
@@ -123,7 +130,7 @@ describe('metadata()', function() {
 
       assert.equal(data.path, './assets/image.jpg');
       assert.equal(data.name, '');
-      assert.equal(data.size, '4.296MB');
+      assert.equal(data.size, 4504682);
       assert.equal(data.format, 'JPEG');
       assert.equal(data.colorspace, 'RGB');
       assert.equal(data.height, 3456);


### PR DESCRIPTION
PR for https://github.com/Turistforeningen/node-s3-uploader/issues/10
Added a dependency though to handle to the conversion of human readable size to plain bytes.
